### PR TITLE
23 nov updates

### DIFF
--- a/.shellconfig.sh
+++ b/.shellconfig.sh
@@ -211,7 +211,7 @@ if [ -x "$(whereis vagrant |cut -d' ' -f2)" ]; then
     UUID=$(cat /proc/sys/kernel/random/uuid)
     TMP_DIR="/tmp/vmspan.$UUID"
     if mkdir "${TMP_DIR}"; then
-      cd "${TMP_DIR}"
+      cd "${TMP_DIR}" || return 1
     else
       return 1
     fi

--- a/.shellconfig.sh
+++ b/.shellconfig.sh
@@ -222,7 +222,11 @@ if [ -x "$(whereis vagrant |cut -d' ' -f2)" ]; then
     IMAGE="${1:?'no image name given'}"
     UUID=$(cat /proc/sys/kernel/random/uuid)
     TMP_DIR="/tmp/vmspan.$UUID"
-    (mkdir "${TMP_DIR}" && cd "${TMP_DIR}") || return 1
+    if mkdir "${TMP_DIR}"; then
+      cd "${TMP_DIR}"
+    else
+      return 1
+    fi
     printf \
       "Vagrant.configure('2') do |config|\n\tconfig.vm.box = '%s'\nend\n" \
       "${IMAGE}" > Vagrantfile

--- a/.shellconfig.sh
+++ b/.shellconfig.sh
@@ -11,6 +11,11 @@ if [ -n "${PATH##*/.local/bin*}" ]; then
   export PATH=$PATH:/home/${SUDO_USER-$USER}/.local/bin
 fi
 
+# user default python virtual env in ~/.venv
+if [ -n "${PATH##*/.venv/bin*}" ]; then
+  export PATH=$PATH:/home/${SUDO_USER-$USER}/.venv/bin
+fi
+
 # use vim if possible, nano otherwise
 if [ -x "$(whereis vim |cut -d' ' -f2)" ]; then
   export VISUAL="vim"

--- a/.shellconfig.sh
+++ b/.shellconfig.sh
@@ -104,7 +104,7 @@ case $ID in
     }
     ;;
 
-  fedora)
+  fedora|centos)
     alias upd="sudo dnf check-update --refresh --assumeno"
     alias updnow="sudo dnf update --assumeyes"
     alias ipkg="sudo dnf install -y"
@@ -113,18 +113,6 @@ case $ID in
     alias cleanpm="sudo dnf clean all"
     ilpkg () {
       sudo dnf install -y "./${1}"
-    }
-    ;;
-
-  centos)
-    alias upd="sudo yum update --assumeno"
-    alias updnow="sudo yum update -y"
-    alias ipkg="sudo yum install -y"
-    alias rpkg="sudo yum remove"
-    alias gpkg="rpm -qa | grep -i"
-    alias cleanpm="sudo yum clean all"
-    ilpkg () {
-      sudo yum install -y "./${1}"
     }
     ;;
 

--- a/.shellconfig.sh
+++ b/.shellconfig.sh
@@ -229,7 +229,7 @@ if [ -x "$(whereis vagrant |cut -d' ' -f2)" ]; then
     fi
     printf \
       "Vagrant.configure('2') do |config|\n\tconfig.vm.box = '%s'\nend\n" \
-      "${IMAGE}" > Vagrantfile
+      "${IMAGE}" > "${TMP_DIR}/Vagrantfile"
     vagrant up
     vagrant ssh
     vagrant destroy -f

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Yet another shell configuration repository
 
-[![Actions Status](https://github.com/replicajune/shellconfig/workflows/shelcheck/badge.svg)](https://github.com/replicajune/shellconfig/actions)
+[![Actions Status](https://github.com/replicajune/shellconfig/workflows/Shellcheck/badge.svg)](https://github.com/replicajune/shellconfig/actions)
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Yet another shell configuration repository
 
-[![Build Status](https://travis-ci.org/replicajune/shellconfig.svg?branch=master)](https://travis-ci.org/replicajune/shellconfig)
+[![Actions Status](https://github.com/replicajune/shellconfig/workflows/shelcheck/badge.svg)](https://github.com/replicajune/shellconfig/actions)
 
 ## Install
 
@@ -17,6 +17,8 @@ if [ -f "/home/${SUDO_USER-$USER}/.shellconfig/.shellconfig.sh" ]; then
   . "/home/${SUDO_USER-$USER}/.shellconfig/.shellconfig.sh"
 fi
 ```
+
+> Using `${SUDO_USER-$USER}` allow to source that same file while you're root through sudo. Root will show as user in red in your PS1
 
 ## Notes
 


### PR DESCRIPTION
- using GitHub actions badge for Shellcheck linting
- fix an issue in vmspan where the Vagrantfile would be created and used from home directory
- using dnf if centos is used. assuming centos 8 by default